### PR TITLE
"dedicated" parameter in toOperator()

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,16 @@ Takes a ssb-ql-0 `query` (an object or JSON as a string), validates it, and
 parses it (if necessary) to return a query object. If anything went wrong during
 validation, returns null.
 
-#### `toOperator(query)`
+#### `toOperator(query[, dedicated])`
 
 Takes a ssb-ql-0 `query` (an object or JSON as a string), validates it, parses
 it (if necessary) and then converts the query to an [ssb-db2](https://github.com/ssb-ngi-pointer/ssb-db2)
 operator which can be inserted inside an ssb-db2 `where()`. If anything went
 wrong during validation, it throws an error.
+
+A second optional argument, `dedicated`, is a boolean that indicates whether the
+underlying database should use dedicated index files for `type` and `author`. By
+default, this is `false`.
 
 #### `stringify(query)`
 
@@ -66,10 +70,13 @@ Takes a ssb-ql-1 `query` (an object or JSON as a string), and parses it (if
 necessary) to return a query object. If anything went wrong during validation,
 returns null.
 
-#### `toOperator(query)`
+#### `toOperator(query[, dedicated])`
 
 Takes a ssb-ql-1 `query` (an object), and converts it to an [ssb-db2](https://github.com/ssb-ngi-pointer/ssb-db2)
 operator which can be inserted inside an ssb-db2 `where()`.
+
+A second optional argument, `dedicated`, is a boolean indicating whether the
+underlying database should use dedicated index files. By default, it's `false`.
 
 #### `stringify(query)`
 

--- a/ql0.js
+++ b/ql0.js
@@ -57,17 +57,15 @@ function parse(query) {
 
 /**
  * @param {string | QueryQL0} query
+ * @param {boolean} dedicated
  * @returns {object}
  */
-function toOperator(query) {
+function toOperator(query, dedicated = false) {
   validate(query)
   const actualQuery = parse(query)
-  // It's important to use dedicated: false because these operators are usually
-  // created by remote peers and we don't want to give them permission to create
-  // an unbounded amount of new bitvector files in jitdb.
   return and(
-    author(actualQuery.author, { dedicated: false }),
-    type(actualQuery.type, { dedicated: false })
+    author(actualQuery.author, { dedicated }),
+    type(actualQuery.type, { dedicated })
   )
 }
 

--- a/ql1.js
+++ b/ql1.js
@@ -21,28 +21,25 @@ function parse(query) {
   }
 }
 
-// It's important to use dedicated: false because these operators are usually
-// created by remote peers and we don't want to give them permission to create
-// an unbounded amount of new bitvector files in jitdb.
-function toOperator(o) {
+function toOperator(o, dedicated = false) {
   if (!o.op) throw 'missing op'
 
   if (o.op === 'and') {
     if (!Array.isArray(o.args)) throw "args part of 'and' op must be an array"
 
-    let args = o.args.map((op) => toOperator(op))
+    let args = o.args.map((op) => toOperator(op, dedicated))
     return and(...args)
   } else if (o.op === 'or') {
     if (!Array.isArray(o.args)) throw "args part of 'and' op must be an array"
 
-    let args = o.args.map((op) => toOperator(op))
+    let args = o.args.map((op) => toOperator(op, dedicated))
     return or(...args)
   } else if (o.op === 'type') {
     if (typeof o.string !== 'string') throw "'type' must have an string option"
-    return type(o.string, { dedicated: false })
+    return type(o.string, { dedicated })
   } else if (o.op === 'author') {
     if (typeof o.feed !== 'string') throw "'author' must have an feed option"
-    return author(o.feed, { dedicated: false })
+    return author(o.feed, { dedicated })
   } else throw 'Unknown op ' + o.op
 }
 

--- a/test/ql0.js
+++ b/test/ql0.js
@@ -92,10 +92,10 @@ test('QL0.parse() sad inputs', (t) => {
 })
 
 test('QL0.toOperator()', (t) => {
-  const actualOP = QL0.toOperator({ author: ALICE_ID, type: 'vote' })
+  const actualOP = QL0.toOperator({ author: ALICE_ID, type: 'vote' }, true)
   const expectedOP = and(
-    author(ALICE_ID, { dedicated: false }),
-    type('vote', { dedicated: false })
+    author(ALICE_ID, { dedicated: true }),
+    type('vote', { dedicated: true })
   )
   t.deepEquals(actualOP, expectedOP, 'output is correct')
   t.end()

--- a/test/ql1.js
+++ b/test/ql1.js
@@ -6,16 +6,19 @@ const { QL1 } = require('../')
 const ALICE_ID = ssbKeys.generate().id
 
 test('QL1.toOperator()', (t) => {
-  const actualOP = QL1.toOperator({
-    op: 'and',
-    args: [
-      { op: 'type', string: 'vote' },
-      { op: 'author', feed: ALICE_ID },
-    ],
-  })
+  const actualOP = QL1.toOperator(
+    {
+      op: 'and',
+      args: [
+        { op: 'type', string: 'vote' },
+        { op: 'author', feed: ALICE_ID },
+      ],
+    },
+    true
+  )
   const expectedOP = and(
-    type('vote', { dedicated: false }),
-    author(ALICE_ID, { dedicated: false })
+    type('vote', { dedicated: true }),
+    author(ALICE_ID, { dedicated: true })
   )
   t.deepEquals(actualOP, expectedOP, 'output is correct')
   t.end()


### PR DESCRIPTION
I did #2 a bit too fast. It turns out that `ssb-meta-feeds-rpc` needs to use `dedicated: false` when receiving a remote request, but `ssb-index-feed-writer` also uses ssb-subset-ql `toOperator()` **locally**, and it's best to use `dedicated: true` in that case because the performance is better and we don't have unpredictable/unbounded inputs.

So this module just presents a parameter.