### PR TITLE
increase scope of validation

### DIFF
--- a/ql0.js
+++ b/ql0.js
@@ -15,20 +15,25 @@ const EXPECTED_KEYS = ['author', 'type']
  * @returns {undefined}
  */
 function validate(query) {
-  const keys = Object.keys(query)
+  if (!query) throw new Error('query should be truthy: ' + query)
+  if (typeof query !== 'string' && typeof query !== 'object') {
+    throw new Error('query should be a string or an object')
+  }
+  const obj = typeof query === 'string' ? JSON.parse(query) : query
+  const keys = Object.keys(obj)
   if (keys.length > EXPECTED_KEYS.length) {
-    throw new Error('query has too many fields: ' + query)
+    throw new Error('query has too many fields: ' + obj)
   }
   for (const k of EXPECTED_KEYS) {
-    if (!keys.includes(k) || !query[k]) {
-      throw new Error(`query is missing the "${k}" field: ${query}`)
+    if (!keys.includes(k) || !obj[k]) {
+      throw new Error(`query is missing the "${k}" field: ${obj}`)
     }
-    if (typeof query[k] !== 'string') {
-      throw new Error(`query "${k}" should be a valid string: ${query}`)
+    if (typeof obj[k] !== 'string') {
+      throw new Error(`query "${k}" should be a valid string: ${obj}`)
     }
   }
-  if (!Ref.isFeedId(query.author)) {
-    throw new Error(`query.author should be a valid SSB feed ID: ${query}`)
+  if (!Ref.isFeedId(obj.author)) {
+    throw new Error(`query.author should be a valid SSB feed ID: ${obj}`)
   }
 }
 

--- a/test/ql0.js
+++ b/test/ql0.js
@@ -12,6 +12,12 @@ test('QL0.validate() happy inputs', (t) => {
     undefined,
     'validated'
   )
+
+  t.equals(
+    QL0.validate(JSON.stringify({ author: ALICE_ID, type: 'vote' })),
+    undefined,
+    'validated'
+  )
   t.end()
 })
 
@@ -62,6 +68,22 @@ test('QL0.validate() sad inputs', (t) => {
     },
     /should be a valid SSB feed ID/,
     'bad author'
+  )
+
+  t.throws(
+    () => {
+      QL0.validate(null)
+    },
+    /should be truthy/,
+    'bad input'
+  )
+
+  t.throws(
+    () => {
+      QL0.validate(3)
+    },
+    /should be a string or an object/,
+    'bad input'
   )
   t.end()
 })


### PR DESCRIPTION
I just realized that ssb-index-feed-writer `start()` accepts either a string or an object, but validation will fail for strings (while it should pass):

https://github.com/ssb-ngi-pointer/ssb-index-feed-writer/blob/b1e0a78d3cd5107b96a492b566e4800a70def254/index.js#L145-L150

This PR allows the input to `validate()` to be a string.