### PR TITLE
implement validate() for ssb-ql-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ const { QL0 } = require('ssb-subset-ql')
 
 #### `validate(query)`
 
-Takes a `query` (an object) and checks that it satisfies the ssb-ql-0 rules. If
-something is wrong, it throws an error. Otherwise it returns undefined.
+Takes a `query` (string or object) and checks that it satisfies the ssb-ql-0
+rules. If something is wrong, it throws an error. Otherwise it returns
+undefined.
 
 #### `parse(query)`
 
@@ -60,9 +61,11 @@ equivalent.
 
 ### QL1
 
-#### ~~`validate(query)`~~
+#### `validate(query)`
 
-Not yet supported.
+Takes a `query` (string or object) and checks that it satisfies the ssb-ql-1
+rules. If something is wrong, it throws an error. Otherwise it returns
+undefined.
 
 #### `parse(query)`
 
@@ -84,7 +87,7 @@ Takes a ssb-ql-1 `query` (an object), and stringifies it as a JSON string.
 
 #### ~~`isEquals(query1, query2)`~~
 
-Not yet supported.
+Not yet supported. Will always throw an error if you use it.
 
 ## License
 

--- a/test/ql1.js
+++ b/test/ql1.js
@@ -24,6 +24,120 @@ test('QL1.toOperator()', (t) => {
   t.end()
 })
 
+test('QL1.validate() happy inputs', (t) => {
+  t.equals(
+    QL1.validate({
+      op: 'and',
+      args: [
+        { op: 'type', string: 'vote' },
+        { op: 'author', feed: ALICE_ID },
+      ],
+    }),
+    undefined,
+    'validated'
+  )
+
+  t.equals(
+    QL1.validate(
+      JSON.stringify({
+        op: 'and',
+        args: [
+          { op: 'type', string: 'vote' },
+          { op: 'author', feed: ALICE_ID },
+        ],
+      })
+    ),
+    undefined,
+    'validated'
+  )
+  t.end()
+})
+
+test('QL1.validate() sad inputs', (t) => {
+  t.throws(
+    () => {
+      QL1.validate('')
+    },
+    (err) => err.message.startsWith('query should be truthy'),
+    'bad input'
+  )
+
+  t.throws(
+    () => {
+      QL1.validate(3)
+    },
+    (err) => err.message.startsWith('query should be a string or an object'),
+    'bad input'
+  )
+
+  t.throws(
+    () => {
+      QL1.validate({})
+    },
+    (err) => err.message.startsWith('query is missing "op"'),
+    'bad input'
+  )
+
+  t.throws(
+    () => {
+      QL1.validate({ op: 'and', args: 123 })
+    },
+    (err) => err.message.startsWith('"args" field must be an array'),
+    'bad input'
+  )
+
+  t.throws(
+    () => {
+      QL1.validate({
+        op: 'ThisIsNotAValidOperator',
+        args: [
+          { op: 'type', string: 'vote' },
+          { op: 'author', feed: ALICE_ID },
+        ],
+      })
+    },
+    (err) => err.message.startsWith('Unknown "op" field'),
+    'bad input'
+  )
+
+  t.throws(
+    () => {
+      QL1.validate({
+        op: 'and',
+        args: [{ op: 'type' }, { op: 'author', feed: ALICE_ID }],
+      })
+    },
+    (err) => err.message.startsWith('"type" in the query must have a "string"'),
+    'bad input'
+  )
+
+  t.throws(
+    () => {
+      QL1.validate({
+        op: 'and',
+        args: [{ op: 'type', string: 'vote' }, { op: 'author' }],
+      })
+    },
+    (err) => err.message.startsWith('"author" in the query must have a "feed"'),
+    'bad input'
+  )
+
+  t.throws(
+    () => {
+      QL1.validate({
+        op: 'or',
+        args: [
+          { op: 'ThisIsNotAValidOP', string: 'vote' },
+          { op: 'author', feed: ALICE_ID },
+        ],
+      })
+    },
+    (err) => err.message.startsWith('Unknown "op" field'),
+    'bad input'
+  )
+  t.end()
+})
+
 test('QL1.stringify()', (t) => {
   const q1 = {
     op: 'and',
@@ -34,5 +148,29 @@ test('QL1.stringify()', (t) => {
   }
   t.equals(QL1.stringify(q1), JSON.stringify(q1), 'same as JSON.stringify')
 
+  t.end()
+})
+
+test('QL1.isEquals() is not supported (yet)', (t) => {
+  t.throws(() => {
+    QL1.isEquals(
+      {
+        op: 'and',
+        args: [
+          { op: 'type', string: 'vote' },
+          { op: 'author', feed: ALICE_ID },
+        ],
+      },
+      {
+        op: 'and',
+        args: [
+          { op: 'type', string: 'vote' },
+          { op: 'author', feed: ALICE_ID },
+        ],
+      }
+    ),
+      (err) => err.message.startsWith('QL1.isEquals() is not supported'),
+      'throws error'
+  })
   t.end()
 })


### PR DESCRIPTION
First I noticed that ssb-ql-1 code was doing `throw 'badcafe'` instead of `throw new Error('badcafe')` so I started converting those. Then I realized that `toOperator()` was really doing validation at the same time as it was converting to an operator, so I extracted that code and put it into `validate()`. 

Plus tests.