### PR TITLE
fix QL0 stringify when type is null

### DIFF
--- a/ql0.js
+++ b/ql0.js
@@ -100,7 +100,11 @@ function stringify(query) {
   validate(query)
   const { author, type, private } = query
   // Doesn't use JSON.stringify because we want to ensure this exact order
-  return `{"author":"${author}","type":"${type}","private":${private}}`
+  if (type === null) {
+    return `{"author":"${author}","type":null,"private":${private}}`
+  } else {
+    return `{"author":"${author}","type":"${type}","private":${private}}`
+  }
 }
 
 /**

--- a/test/ql0.js
+++ b/test/ql0.js
@@ -189,6 +189,13 @@ test('QL0.stringify()', (t) => {
   const q2 = { type: 'vote', author: ALICE_ID, private: false }
   t.equals(QL0.stringify(q2), JSON.stringify(q1), 'order is author & type')
   t.notEquals(QL0.stringify(q2), JSON.stringify(q2), 'order is stable')
+
+  const q3 = { author: ALICE_ID, type: null, private: true }
+  const q3str = QL0.stringify(q3)
+  t.equals(q3str, JSON.stringify(q3), 'same as JSON')
+  const parsed3 = QL0.parse(q3str)
+  t.deepEquals(parsed3, q3, 'supports stringifying null type')
+
   t.end()
 })
 


### PR DESCRIPTION
When we `QL0.stringify({ author: 'feedid', type: null, private: true })`, it should become 

`{"author":"feedid","type":null,"private":true}`

but in reality it was

`{"author":"feedid","type":"null","private":true}`

Note `"type":null` versus `"type":"null"`. The latter is a string, and that's not what we need.
